### PR TITLE
Add tripId to payload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.hsl.transitdata</groupId>
     <artifactId>transitdata-hslalert-source</artifactId>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
     <packaging>jar</packaging>
 
     <repositories>
@@ -18,7 +18,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <pulsar.version>2.1.0-incubating</pulsar.version>
-        <common.version>0.7.5</common.version>
+        <common.version>0.8.1</common.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/fi/hsl/transitdata/hslalertsource/HslAlertPoller.java
+++ b/src/main/java/fi/hsl/transitdata/hslalertsource/HslAlertPoller.java
@@ -77,8 +77,9 @@ public class HslAlertPoller {
         }
     }
 
-    static InternalMessages.TripCancellation createPulsarPayload(final GtfsRealtime.TripDescriptor tripDescriptor, int joreDirection) {
+    static InternalMessages.TripCancellation createPulsarPayload(final GtfsRealtime.TripDescriptor tripDescriptor, int joreDirection, String dvjId) {
         InternalMessages.TripCancellation.Builder builder = InternalMessages.TripCancellation.newBuilder()
+                .setTripId(dvjId)
                 .setRouteId(tripDescriptor.getRouteId())
                 .setDirectionId(joreDirection)
                 .setStartDate(tripDescriptor.getStartDate())
@@ -105,7 +106,7 @@ public class HslAlertPoller {
                         tripDescriptor.getStartTime());
                 final String dvjId = jedis.get(cacheKey);
                 if (dvjId != null) {
-                    InternalMessages.TripCancellation tripCancellation = createPulsarPayload(tripDescriptor, joreDirection);
+                    InternalMessages.TripCancellation tripCancellation = createPulsarPayload(tripDescriptor, joreDirection, dvjId);
 
                     producer.newMessage().value(tripCancellation.toByteArray())
                             .eventTime(timestamp)

--- a/src/test/java/fi/hsl/transitdata/hslalertsource/HslAlertPollerTest.java
+++ b/src/test/java/fi/hsl/transitdata/hslalertsource/HslAlertPollerTest.java
@@ -38,8 +38,9 @@ public class HslAlertPollerTest {
     private void validateInternalMessage(GtfsRealtime.TripUpdate update) {
         final GtfsRealtime.TripDescriptor trip = update.getTrip();
         final int joreDirection = trip.getDirectionId() + 1;
-        final InternalMessages.TripCancellation cancellation = HslAlertPoller.createPulsarPayload(trip, joreDirection);
+        final InternalMessages.TripCancellation cancellation = HslAlertPoller.createPulsarPayload(trip, joreDirection, trip.getTripId());
 
+        assertEquals(trip.getTripId(), cancellation.getTripId());
         assertEquals(joreDirection, cancellation.getDirectionId());
         assertEquals(trip.getRouteId(), cancellation.getRouteId());
 


### PR DESCRIPTION
fixes https://github.com/HSLdevcom/transitdata-hslalert-source/issues/13

should not break anything downstream since it's an optional field. 